### PR TITLE
DLC Database. Up to date 9/20/2022

### DIFF
--- a/data/id_database.json
+++ b/data/id_database.json
@@ -508,26 +508,6 @@
             }],
             "Archived": []
         },
-        "54540092": {
-            "Title Name": "ESPN Major League Baseball 2K6",
-            "Content IDs": [
-                "5454009220060508",
-                "5454009220060614",
-                "5454009220060906"
-            ],
-            "Title Updates": [],
-            "Title Updates Known": [],
-            "Archived": []
-        },
-        "545400b1": {
-            "Title Name": "ESPN Major League Baseball 2K7",
-            "Content IDs": [
-                "545400b120070212"
-            ],
-            "Title Updates": [],
-            "Title Updates Known": [],
-            "Archived": []
-        },
         "53450031": {
             "Title Name": "ESPN NBA 2K5",
             "Content IDs": [
@@ -1090,6 +1070,20 @@
                 "4d53005d00000002": "OM Director's Cut",
                 "4d53005d00000004": "The Gallery"
         }]},
+        "4947000e": {
+            "Title Name": "Magic The Gathering Battlegrounds",
+            "Content IDs": [
+                "4947000e00000002"
+            ],
+            "Title Updates": [
+                "0000000100000201"
+            ],
+            "Title Updates Known": [{
+                "05dd4b7e16aea18b2319b72596dd2760e816940e": "0000000100000201:RF 0201"
+            }],
+            "Archived": [{
+                "4947000e00000002": "Expansion Pack"
+        }]},		
         "53450037": {
             "Title Name": "Major League Baseball 2K5",
             "Content IDs": [
@@ -1104,20 +1098,27 @@
             "Title Updates Known": [],
             "Archived": []
         },
-        "4947000e": {
-            "Title Name": "Magic The Gathering Battlegrounds",
+        "54540092": {
+            "Title Name": "Major League Baseball 2K6",
             "Content IDs": [
-                "4947000e00000002"
+                "5454009220060508",
+                "5454009220060614",
+                "5454009220060906"
             ],
-            "Title Updates": [
-                "0000000100000201"
+            "Title Updates": [],
+            "Title Updates Known": [],
+            "Archived": []
+        },
+        "545400b1": {
+            "Title Name": "Major League Baseball 2K7",
+            "Content IDs": [
+                "545400b120070212"
             ],
-            "Title Updates Known": [{
-                "05dd4b7e16aea18b2319b72596dd2760e816940e": "0000000100000201:RF 0201"
-            }],
-            "Archived": [{
-                "4947000e00000002": "Expansion Pack"
-        }]},
+            "Title Updates": [],
+            "Title Updates Known": [],
+            "Archived": []
+        },		
+
         "4d530017": {
             "Title Name": "MechAssault",
             "Content IDs": [
@@ -1195,8 +1196,11 @@
             "Archived": [{
                 "4d53001700000001": "1 - Hell's Kitchen",
                 "4d53001700000005": "2 - Raven",
+                "4d53001700000008": "2 - Raven (Region 4)",
                 "4d53001700000009": "3 - Stone Cold",
+                "4d5300170000000c": "3 - Stone Cold (Region 4)",
                 "4d5300170000000d": "4 - Corvus",
+                "4d53001700000010": "4 - Corvus (Region 4)",
                 "4d53001700000011": "5 - Midtown Mayhem",
                 "4d53001700000014": "5 - Midtown Mayhem (Region 4)",
                 "4d53001700000015": "6 - Desert Storm",
@@ -1206,9 +1210,11 @@
                 "4d5300170000001d": "8 - Loki",
                 "4d53001700000020": "8 - Loki (Region 4)",
                 "4d53001700000021": "9 - Demolition Town",
+                "4d53001700000024": "9 - Demolition Town (Region 4)",
                 "4d53001700000025": "10 - Rock Solid",
                 "4d53001700000029": "11 - Jotenheim",
                 "4d5300170000002d": "12 - Gametypes",
+                "4d53001700000030": "12 - Gametypes (Region 4)",
                 "4d53001700000035": "14 - Objective Package"
         }]},
         "4d53006b": {


### PR DESCRIPTION
Added newly archived  Mechassault Region 4 DLCs, thanks HALO (AUS)!

Rearranged some ESPN titles based on box title.
Moved Magic the Gathering: Battlegrounds to the correct location.